### PR TITLE
Support static bearer tokens for authenticating with upstream MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ $ mcpjungle deregister calculator
 
 After running this, the registry will stop tracking this server and its tools will no longer be available to use.
 
+### Authentication
+MCPJungle currently supports authentication if your MCP Server accepts static tokens for auth.
+
+This is useful when using SaaS-provided MCP Servers like HuggingFace, Stripe, etc. which require your API token for authentication.
+
+You can supply your token while registering the MCP server:
+```bash
+# If you specify the `--bearer-token` flag, MCPJungle will add the `Authorization: Bearer <token>` header to all requests made to this MCP server.
+$ mcpjungle register --name huggingface --description "HuggingFace MCP Server" --url https://hf.co/mcp --bearer-token <your-hf-api-token>
+```
+
+Support for other auth methods like Oauth is coming soon!
+
 ## Development
 
 This section contains notes for maintainers and contributors of MCPJungle.

--- a/client/mcp_server.go
+++ b/client/mcp_server.go
@@ -15,15 +15,23 @@ type Server struct {
 	URL         string `json:"url"`
 }
 
-// RegisterServer registers a new MCP server with the registry.
-func (c *Client) RegisterServer(name, url, description string) (*Server, error) {
-	u, _ := c.constructAPIEndpoint("/servers")
-	server := &Server{
-		Name:        name,
-		Description: description,
-		URL:         url,
-	}
+// RegisterServerInput is the input structure for registering a new MCP server.
+type RegisterServerInput struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
 
+	// URL is mandatory and must be a valid http/https URL (eg- https://example.com/mcp).
+	// MCPJungle only supports streamable HTTP transport as of now.
+	URL string `json:"url"`
+
+	// BearerToken is an optional token used for authenticating requests to the MCP server.
+	// It is useful when the upstream MCP server requires static tokens (e.g., API tokens) for authentication.
+	BearerToken string `json:"bearer_token,omitempty"`
+}
+
+// RegisterServer registers a new MCP server with the registry.
+func (c *Client) RegisterServer(server *RegisterServerInput) (*Server, error) {
+	u, _ := c.constructAPIEndpoint("/servers")
 	body, err := json.Marshal(server)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize server data into JSON: %w", err)

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -2,13 +2,15 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/duaraghav8/mcpjungle/client"
 	"github.com/spf13/cobra"
 )
 
 var (
-	registerCmdServerName string
-	registerCmdServerURL  string
-	registerCmdServerDesc string
+	registerCmdServerName  string
+	registerCmdServerURL   string
+	registerCmdServerDesc  string
+	registerCmdBearerToken string
 )
 
 var registerMCPServerCmd = &cobra.Command{
@@ -37,6 +39,13 @@ func init() {
 		"",
 		"Server description",
 	)
+	registerMCPServerCmd.Flags().StringVar(
+		&registerCmdBearerToken,
+		"bearer-token",
+		"",
+		"If provided, MCPJungle will use this token to authenticate with the MCP server for all requests."+
+			" This is useful if the MCP server requires static tokens (eg- your API token) for authentication.",
+	)
 
 	// TODO: name should not be mandatory.
 	//  If not supplied, name should be read from MCP server metadata by the registry.
@@ -47,7 +56,13 @@ func init() {
 }
 
 func runRegisterMCPServer(cmd *cobra.Command, args []string) error {
-	s, err := apiClient.RegisterServer(registerCmdServerName, registerCmdServerURL, registerCmdServerDesc)
+	input := &client.RegisterServerInput{
+		Name:        registerCmdServerName,
+		URL:         registerCmdServerURL,
+		Description: registerCmdServerDesc,
+		BearerToken: registerCmdBearerToken,
+	}
+	s, err := apiClient.RegisterServer(input)
 	if err != nil {
 		return fmt.Errorf("failed to register server: %w", err)
 	}

--- a/internal/model/mcp_server.go
+++ b/internal/model/mcp_server.go
@@ -8,8 +8,16 @@ import (
 type McpServer struct {
 	ID          uuid.UUID `json:"-" gorm:"type:uuid;primaryKey"`
 	Name        string    `json:"name" gorm:"uniqueIndex;not null"`
-	URL         string    `json:"url" gorm:"not null"`
 	Description string    `json:"description"`
+
+	// URL must be a valid http/https URL.
+	// MCPJungle only supports streamable HTTP transport as of now.
+	URL string `json:"url" gorm:"not null"`
+
+	// TODO: Store the bearer token in a more secure way, e.g., encrypted in the database.
+	// BearerToken is an optional token used for authenticating requests to the MCP server.
+	// If present, it will be used to set the Authorization header in all requests to this MCP server.
+	BearerToken string `json:"bearer_token,omitempty" gorm:"type:text"`
 }
 
 func (s *McpServer) BeforeCreate(tx *gorm.DB) (err error) {

--- a/internal/service/proxy.go
+++ b/internal/service/proxy.go
@@ -53,7 +53,7 @@ func (m *MCPService) mcpProxyToolCallHandler(ctx context.Context, request mcp.Ca
 	}
 
 	// connect to the upstream MCP server that actually provides the tool
-	mcpClient, err := createMcpServerConn(ctx, server.URL)
+	mcpClient, err := createMcpServerConn(ctx, server)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to create connection to MCP server %s: %w", serverName, err,

--- a/internal/service/server.go
+++ b/internal/service/server.go
@@ -15,8 +15,10 @@ func (m *MCPService) RegisterMcpServer(ctx context.Context, s *model.McpServer) 
 		return err
 	}
 
+	// TODO: validate the URL to ensure it is a valid HTTP/HTTPS URL (streamable http compliant)
+
 	// test that the server is reachable and is MCP-compliant
-	c, err := createMcpServerConn(ctx, s.URL)
+	c, err := createMcpServerConn(ctx, s)
 	if err != nil {
 		return fmt.Errorf("failed to connect to MCP server %s: %w", s.Name, err)
 	}

--- a/internal/service/tool.go
+++ b/internal/service/tool.go
@@ -86,7 +86,7 @@ func (m *MCPService) InvokeTool(ctx context.Context, name string, args map[strin
 		)
 	}
 
-	mcpClient, err := createMcpServerConn(ctx, serverModel.URL)
+	mcpClient, err := createMcpServerConn(ctx, serverModel)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to create connection to MCP server %s: %w", serverName, err,


### PR DESCRIPTION
Implements part of #6 
also addresses #4 auth issue